### PR TITLE
Handle spaces around topic names

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "file", "f", defaultDockerCompose(), "docker-compose (default is $PWD/docker-compose.yml)")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "file", "f", defaultDockerCompose(), "docker-compose file")
 }
 
 func defaultDockerCompose() string {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -79,7 +79,7 @@ func waitForTopics(service *dockercompose.Service, expectedTopics []string) {
 		if eql(foundTopics, expectedTopics) {
 			return
 		}
-		// fmt.Print(".")
+		fmt.Print(".")
 		time.Sleep(time.Second)
 	}
 	if eql(createdTopics(service), expectedTopics) {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -12,11 +12,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Seconds to wait for kafka topic creation to finish
-const maximumWaitTime = 30
+var timeout uint32
 
 func init() {
 	rootCmd.AddCommand(upCmd)
+	upCmd.PersistentFlags().Uint32VarP(&timeout, "timeout", "t", 30, "seconds to wait on the topics to become ready")
 }
 
 var upCmd = &cobra.Command{
@@ -56,7 +56,7 @@ func doUpCmd(cmd *cobra.Command, _args []string) {
 	fmt.Printf("docker-compose -f %s up -d\n", dockerFilePath)
 	dockerComposeUp(dockerFilePath)
 
-	fmt.Print("waiting for topics to be created")
+	fmt.Println("waiting for topics to be created")
 	waitForTopics(&kafkaService, topics)
 	fmt.Println("\ndone.")
 }
@@ -69,19 +69,24 @@ func dockerComposeUp(dockerFilePath string) {
 		fmt.Printf("STDERR:\n%s\n", stderr)
 		os.Exit(err)
 	}
-
 }
 
 // waitForTopics queries the running kafka instance to see if the topics are available
 func waitForTopics(service *dockercompose.Service, expectedTopics []string) {
 	// Wait for a bit for topics to be created (should take < 5 seconds)
-	for i := 0; i < maximumWaitTime; i++ {
-		if eql(createdTopics(service), expectedTopics) {
+	for i := uint32(0); i < timeout; i++ {
+		foundTopics := createdTopics(service)
+		if eql(foundTopics, expectedTopics) {
 			return
 		}
-		fmt.Print(".")
+		// fmt.Print(".")
 		time.Sleep(time.Second)
 	}
+	if eql(createdTopics(service), expectedTopics) {
+		return
+	}
+	msg := fmt.Sprintf("Kafka Topics did not become available after %d seconds", timeout)
+	panic(msg)
 }
 
 func createdTopics(service *dockercompose.Service) []string {
@@ -94,7 +99,9 @@ func createdTopics(service *dockercompose.Service) []string {
 		fmt.Printf("STDERR:\n%s\n", stderr)
 		os.Exit(err)
 	}
-	topics := strings.Split(strings.TrimSpace(stdout), "\n")
+	rawTopics := strings.Split(strings.TrimSpace(stdout), "\n")
+	// Internal topic
+	topics := removeElem(rawTopics, "__consumer_offsets")
 	return topics
 }
 
@@ -111,4 +118,20 @@ func eql(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func removeElem(s []string, e string) []string {
+	k := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == e {
+			k = i
+			break
+		}
+	}
+	if k >= 0 {
+		s[k] = s[len(s)-1]
+		// We do not need to put s[i] at the end, as it will be discarded anyway
+		return s[:len(s)-1]
+	}
+	return s
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+# Example working docker-compose file
+version: "3.2"
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+  kafka1:
+    image: wurstmeister/kafka:2.11-1.1.1
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_CREATE_TOPICS: "topic1:12:3, topic2:12:3, atopic3:12:3"
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${DOCKER_IP}:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  kafka2:
+    image: wurstmeister/kafka:2.11-1.1.1
+    ports:
+      - "9093:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${DOCKER_IP}:9093
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  kafka3:
+    image: wurstmeister/kafka:2.11-1.1.1
+    ports:
+      - "9094:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${DOCKER_IP}:9094
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -68,7 +68,7 @@ func (service *Service) GetTopics() []string {
 	topics := make([]string, len(topicDefinitions))
 	for i := 0; i < len(topicDefinitions); i++ {
 		topicDefinition := strings.Split(topicDefinitions[i], ":")
-		topics[i] = topicDefinition[0]
+		topics[i] = strings.TrimSpace(topicDefinition[0])
 	}
 	return topics
 }


### PR DESCRIPTION
This fixes a few bugs:
* If the KAFKA_CREATE_TOPICS had extra spaces in the comma-separated field, it failed to match the detected created topics, which meant that it would time out.
* If the topic creation timeout was reached, there was no indication of the failure. For now, I have it panic(). This could do with a better message eventually.

Also adds a couple features
* added an example docker-compose.yml file.
* Added a --timeout option to choose the timeout.