### PR TITLE
BE-5213

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @ipryseski
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+# docs/*  docs@example.com

--- a/README.md
+++ b/README.md
@@ -53,9 +53,17 @@ services:
 ```
 
 ## Usage
-
+Bring kafka containers online
 ```
 kafka_docker up [-f|--file <docker-compose-file>]
+```
+Halt kafka docker containers
+```
+kafka_docker down [-f|--file <docker-compose-file>]
+```
+Display ip associated to docker containers
+```
+kafka_docker ip 
 ```
 
 ## Testing

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -27,5 +27,5 @@ func dockerComposeIP() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("%s", dockerIP)
+	fmt.Printf("%s\n", dockerIP)
 }

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/simplifi/kafka_docker/internal/dockercompose"
 	"github.com/spf13/cobra"
@@ -29,5 +28,4 @@ func dockerComposeIP() {
 		panic(err)
 	}
 	fmt.Printf("%s", dockerIP)
-	os.Setenv("DOCKER_IP", dockerIP)
 }

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/simplifi/kafka_docker/internal/dockercompose"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(ipCmd)
+}
+
+var ipCmd = &cobra.Command{
+	Use:   "ip",
+	Short: "Outputs Docker IP",
+	Args:  cobra.MaximumNArgs(0),
+	Run:   doipCmd,
+}
+
+func doipCmd(cmd *cobra.Command, _args []string) {
+	dockerComposeIP()
+}
+
+func dockerComposeIP() {
+	dockerIP, err := dockercompose.DockerIP()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s", dockerIP)
+	os.Setenv("DOCKER_IP", dockerIP)
+}


### PR DESCRIPTION
https://simplifi.atlassian.net/browse/BE-5263

- Added a IP command to pull back ip used for docker containers.
- - Used to replace some functionality from sifi_docker_fu
- Added CODEOWNER