### PR TITLE
they changed the config format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ archives:
   - format: tar.gz
 
 brews:
-  - github:
+  - tap:
       owner: simplifi
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
The goreleaser brews config section has been changed and `github` is now named `tap`. Releases are currently failing on master.