### PR TITLE
Polish get kafka docker

### DIFF
--- a/scripts/get_kafka_docker
+++ b/scripts/get_kafka_docker
@@ -45,12 +45,12 @@ else
 fi
 release_json=`gh_curl -s $GITHUB/repos/$REPO/releases/$VERSION_TAG`
 
-# In the assets array of release_json, find asset with name matching PATTERN and store its id
-asset_id=`jq ".assets | map(select(.name | test(\"$PATTERN\")))[0].id" <<< "$release_json"`
+# In the assets array of release_json, find asset with name matching PATTERN and store its url
+asset_url=`jq -r ".assets | map(select(.name | test(\"$PATTERN\")))[0].url" <<< "$release_json"`
 
-if [ "$asset_id" = "null" ]; then
+if [ "$asset_url" = "null" ]; then
   errcho "ERROR: version not found $VERSION"
   exit 1
 fi
 
-curl -L -H 'Accept: application/octet-stream' $GITHUB/repos/$REPO/releases/assets/$asset_id | tar -xz --exclude="README.md" --exclude="LICENSE"
+curl -L -H 'Accept: application/octet-stream' $asset_url | tar -xz --exclude="README.md" --exclude="LICENSE"

--- a/scripts/get_kafka_docker
+++ b/scripts/get_kafka_docker
@@ -37,15 +37,17 @@ function gh_curl() {
   curl $@ -H "Accept: application/vnd.github.v3.raw"
 }
 
+# Get data on just the release we're looking for from the api
 if [ "$VERSION" = "latest" ]; then
-  # Github should return the latest release first.
-  parser=".[0].assets | map(select(.name | test(\"$PATTERN\")))[0].id"
+  VERSION_TAG="latest"
 else
-  parser=". | map(select(.tag_name == \"$VERSION\"))[0].assets | map(select(.name | test(\"$PATTERN\")))[0].id"
+  VERSION_TAG="tags/$VERSION"
 fi
+release_json=`gh_curl -s $GITHUB/repos/$REPO/releases/$VERSION_TAG`
 
-gh_curl -s $GITHUB/repos/$REPO/releases
-asset_id=`gh_curl -s $GITHUB/repos/$REPO/releases | jq "$parser"`
+# In the assets array of release_json, find asset with name matching PATTERN and store its id
+asset_id=`jq ".assets | map(select(.name | test(\"$PATTERN\")))[0].id" <<< "$release_json"`
+
 if [ "$asset_id" = "null" ]; then
   errcho "ERROR: version not found $VERSION"
   exit 1

--- a/scripts/get_kafka_docker
+++ b/scripts/get_kafka_docker
@@ -22,7 +22,6 @@
 
 set -x
 
-TOKEN=$GITHUB_TOKEN
 REPO=simplifi/kafka_docker
 # target architecture
 ARCH="linux_amd64"
@@ -35,9 +34,7 @@ GITHUB="https://api.github.com"
 alias errcho='>&2 echo'
 
 function gh_curl() {
-  curl -H "Authorization: token $TOKEN" \
-       -H "Accept: application/vnd.github.v3.raw" \
-       $@
+  curl $@ -H "Accept: application/vnd.github.v3.raw"
 }
 
 if [ "$VERSION" = "latest" ]; then
@@ -54,4 +51,4 @@ if [ "$asset_id" = "null" ]; then
   exit 1
 fi;
 
-curl -L -H 'Accept:application/octet-stream' https://$TOKEN:@api.github.com/repos/$REPO/releases/assets/$asset_id | tar -xz --exclude="README.md" --exclude="LICENSE"
+curl -L -H 'Accept: application/octet-stream' $GITHUB/repos/$REPO/releases/assets/$asset_id | tar -xz --exclude="README.md" --exclude="LICENSE"

--- a/scripts/get_kafka_docker
+++ b/scripts/get_kafka_docker
@@ -24,11 +24,11 @@ set -x
 
 REPO=simplifi/kafka_docker
 # target architecture
-ARCH="linux_amd64"
+ARCH="${ARCH:-linux_amd64}"
 # regular expression for the desired download
 PATTERN="kafka_docker_\\\\d+\\\\.\\\\d+\\\\.\\\\d+_${ARCH}\\\\.tar\\\\.gz"
 # tag name or the word "latest"
-VERSION=latest
+VERSION=${VERSION:-latest}
 GITHUB="https://api.github.com"
 
 alias errcho='>&2 echo'

--- a/scripts/get_kafka_docker
+++ b/scripts/get_kafka_docker
@@ -42,13 +42,13 @@ if [ "$VERSION" = "latest" ]; then
   parser=".[0].assets | map(select(.name | test(\"$PATTERN\")))[0].id"
 else
   parser=". | map(select(.tag_name == \"$VERSION\"))[0].assets | map(select(.name | test(\"$PATTERN\")))[0].id"
-fi;
+fi
 
 gh_curl -s $GITHUB/repos/$REPO/releases
 asset_id=`gh_curl -s $GITHUB/repos/$REPO/releases | jq "$parser"`
 if [ "$asset_id" = "null" ]; then
   errcho "ERROR: version not found $VERSION"
   exit 1
-fi;
+fi
 
 curl -L -H 'Accept: application/octet-stream' $GITHUB/repos/$REPO/releases/assets/$asset_id | tar -xz --exclude="README.md" --exclude="LICENSE"


### PR DESCRIPTION
I cleaned up get_kafka_docker to address a few problems:
It shouldn't need to have a `GITHUB_TOKEN`
It shouldn't request the releases list data when we already know the tag we want and can get just that release's datum.
It should just the release's `url` directly, instead of rebuilding that using the release's `id` and our other variables.
There should be a way to specify `VERSION` and `ARCH` at call-time.

Also I added some comments explaining what some of the more involved lines in this script do.