### PR TITLE
Fix get_kafka_docker only working on mac 😅

### DIFF
--- a/scripts/get_kafka_docker
+++ b/scripts/get_kafka_docker
@@ -46,7 +46,7 @@ fi
 release_json=`gh_curl -s $GITHUB/repos/$REPO/releases/$VERSION_TAG`
 
 # In the assets array of release_json, find asset with name matching PATTERN (case insensitively) and store its url
-asset_url=`jq -r ".assets | map(select(.name | test(\"$PATTERN\", \"i\")))[0].url" <<< "$release_json"`
+asset_url=`jq -r ".assets | map(select(.name | test(\"$PATTERN\"; \"i\")))[0].url" <<< "$release_json"`
 
 if [ "$asset_url" = "null" ]; then
   errcho "ERROR: version not found $KAFKA_DOCKER_VERSION"


### PR DESCRIPTION
semicolons aren't commas
(tested to work properly if `uname -s` returns `Darwin` or `Linux`)