### PR TITLE
Fix `kafka_docker up` failing during `docker-compose exec` when `-f` is provided

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -90,8 +90,9 @@ func waitForTopics(service *dockercompose.Service, expectedTopics []string) {
 }
 
 func createdTopics(service *dockercompose.Service) []string {
-	// docker-compose exec -T -e topic=$topic kafka1 /bin/bash -c '$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $KAFKA_ZOOKEEPER_CONNECT --list | grep -q $topic'
-	stdout, stderr, err := bash("docker-compose", "exec", "-T", service.Name, "/bin/bash", "-c", "$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $KAFKA_ZOOKEEPER_CONNECT --list")
+	dockerFilePath := rootCmd.PersistentFlags().Lookup("file").Value.String()
+	// docker-compose -f dev-kafka.yml exec -T -e topic=$topic kafka1 /bin/bash -c '$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $KAFKA_ZOOKEEPER_CONNECT --list | grep -q $topic'
+	stdout, stderr, err := bash("docker-compose", "-f", dockerFilePath, "exec", "-T", service.Name, "/bin/bash", "-c", "$KAFKA_HOME/bin/kafka-topics.sh --zookeeper $KAFKA_ZOOKEEPER_CONNECT --list")
 
 	if err != 0 {
 		fmt.Println("Failure running docker-compose exec")


### PR DESCRIPTION
This fixes that when there's no `docker-compose.yml`, kafka_docker will fail to run its `docker-compose exec` command during `kafka_docker up` while waiting for topics to be created.

> ➤ kafka-docker --file='dev-kafka.yml' up
> Using dev-kafka.yml as the docker-compose configuration
> docker-compose service found: kafka, with topics [dev test]
> export DOCKER_IP=192.168.1.195
> docker-compose -f dev-kafka.yml up -d
> waiting for topics to be created
> Failure running docker-compose exec
> STDOUT:
> 
> STDERR:
> no configuration file provided: not found