### PR TITLE
Add platform: 'linux/amd64' key to each service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,12 @@ version: "3.2"
 services:
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
+    platform: 'linux/amd64'
     ports:
       - "2181:2181"
   kafka1:
     image: wurstmeister/kafka:2.11-1.1.1
+    platform: 'linux/amd64'
     ports:
       - "9092:9092"
     depends_on:
@@ -20,6 +22,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
   kafka2:
     image: wurstmeister/kafka:2.11-1.1.1
+    platform: 'linux/amd64'
     ports:
       - "9093:9092"
     depends_on:
@@ -32,6 +35,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
   kafka3:
     image: wurstmeister/kafka:2.11-1.1.1
+    platform: 'linux/amd64'
     ports:
       - "9094:9092"
     depends_on:


### PR DESCRIPTION
This enables an M1 Mac to run this docker-compose in x86_64 emulation mode and causes no changes for docker compose running on x86_64 hardware. 