### PR TITLE
Upgrade go so we can build for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - GO111MODULE=on
 
 go:
-  - 1.13.x
+  - 1.18.x
 
 before_script:
   - GO111MODULE=off go get -u golang.org/x/lint/golint

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,13 @@
 module github.com/simplifi/kafka_docker
 
-go 1.12
+go 1.18
 
 require (
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/yaml.v2 v2.2.2
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
 )


### PR DESCRIPTION
[Build is failing](https://github.com/simplifi/kafka_docker/runs/7133298255) for the latest tag, this should fix it.